### PR TITLE
fix login test with otp

### DIFF
--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -234,6 +234,7 @@ class LoginTest extends TestCase
 
         // TODO: query parameter ordering for asserting redirect
         //$response->assertRedirect($otpUrl);
+        $this->assertStringContainsString($this->otpGetRoute(), $this->responseUrl($response));
         $response->assertSessionHasErrors('one_time_password');
         $this->assertFalse(session()->hasOldInput('one_time_password'));
         $this->assertGuest();


### PR DESCRIPTION
This fixes (at least temporarily) the missing assertion of redirecting back to the OTP page when logging in with two factors and typing a wrong OTP code.