### PR TITLE
extend address validation to company and person forms

### DIFF
--- a/app/Http/Requests/AddressStoreRequest.php
+++ b/app/Http/Requests/AddressStoreRequest.php
@@ -8,13 +8,6 @@ use Illuminate\Validation\Rule;
 
 class AddressStoreRequest extends FormRequest
 {
-    public function messages()
-    {
-        return [
-            'street_number.unique' => 'Eine Addresse mit den angegeben Daten existiert bereits.',
-        ];
-    }
-
     /**
      * Get the validation rules that apply to the request.
      *

--- a/app/Http/Requests/AddressUpdateRequest.php
+++ b/app/Http/Requests/AddressUpdateRequest.php
@@ -8,13 +8,6 @@ use Illuminate\Validation\Rule;
 
 class AddressUpdateRequest extends FormRequest
 {
-    public function messages()
-    {
-        return [
-            'street_number.unique' => 'Eine Addresse mit den angegeben Daten existiert bereits.',
-        ];
-    }
-
     /**
      * Get the validation rules that apply to the request.
      *

--- a/app/Http/Requests/CompanyStoreRequest.php
+++ b/app/Http/Requests/CompanyStoreRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class CompanyStoreRequest extends FormRequest
 {
@@ -11,8 +13,12 @@ class CompanyStoreRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
+    public function rules(Request $request)
     {
+        $street_number = $request->street_number;
+        $postcode = $request->postcode;
+        $city = $request->city;
+
         return [
             'name' => 'required|unique:companies',
             'name_2' => 'nullable',
@@ -21,7 +27,16 @@ class CompanyStoreRequest extends FormRequest
             'email' => 'email|nullable',
             'website' => 'url|nullable',
             'address_id' => 'exists:addresses,id|nullable',
-            'street_number' => 'required_with:postcode,city|nullable',
+            'street_number' => [
+                'required_with:postcode,city',
+                'nullable',
+                Rule::unique('addresses')->where(function ($query) use ($street_number, $postcode, $city) {
+                    return $query
+                        ->where('street_number', $street_number)
+                        ->where('postcode', $postcode)
+                        ->where('city', $city);
+                }),
+            ],
             'postcode' => 'required_with:street_number,city|digits_between:4,5|nullable',
             'city' => 'required_with:street_number,postcode|nullable',
             'comment' => 'nullable',

--- a/app/Http/Requests/CompanyUpdateRequest.php
+++ b/app/Http/Requests/CompanyUpdateRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class CompanyUpdateRequest extends FormRequest
 {
@@ -11,8 +13,12 @@ class CompanyUpdateRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
+    public function rules(Request $request)
     {
+        $street_number = $request->street_number;
+        $postcode = $request->postcode;
+        $city = $request->city;
+
         return [
             'name' => 'required|unique:companies,name,'.$this->company->id,
             'name_2' => 'nullable',
@@ -21,7 +27,16 @@ class CompanyUpdateRequest extends FormRequest
             'email' => 'email|nullable',
             'website' => 'url|nullable',
             'address_id' => 'exists:addresses,id|nullable',
-            'street_number' => 'required_with:postcode,city|nullable',
+            'street_number' => [
+                'required_with:postcode,city',
+                'nullable',
+                Rule::unique('addresses')->where(function ($query) use ($street_number, $postcode, $city) {
+                    return $query
+                        ->where('street_number', $street_number)
+                        ->where('postcode', $postcode)
+                        ->where('city', $city);
+                }),
+            ],
             'postcode' => 'required_with:street_number,city|digits_between:4,5|nullable',
             'city' => 'required_with:street_number,postcode|nullable',
             'comment' => 'nullable',

--- a/app/Http/Requests/PersonStoreRequest.php
+++ b/app/Http/Requests/PersonStoreRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class PersonStoreRequest extends FormRequest
 {
@@ -11,8 +13,12 @@ class PersonStoreRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
+    public function rules(Request $request)
     {
+        $street_number = $request->street_number;
+        $postcode = $request->postcode;
+        $city = $request->city;
+
         return [
             'first_name' => 'required',
             'last_name' => 'required',
@@ -20,7 +26,16 @@ class PersonStoreRequest extends FormRequest
             'title_suffix' => 'nullable',
             'gender' => 'required|in:male,female,neutral',
             'address_id' => 'exists:addresses,id|nullable',
-            'street_number' => 'required_with:postcode,city|nullable',
+            'street_number' => [
+                'required_with:postcode,city',
+                'nullable',
+                Rule::unique('addresses')->where(function ($query) use ($street_number, $postcode, $city) {
+                    return $query
+                        ->where('street_number', $street_number)
+                        ->where('postcode', $postcode)
+                        ->where('city', $city);
+                }),
+            ],
             'postcode' => 'required_with:street_number,city|digits_between:4,5|nullable',
             'city' => 'required_with:street_number,postcode|nullable',
             'company_id' => 'exists:companies,id|nullable',

--- a/app/Http/Requests/PersonUpdateRequest.php
+++ b/app/Http/Requests/PersonUpdateRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class PersonUpdateRequest extends FormRequest
 {
@@ -11,8 +13,12 @@ class PersonUpdateRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
+    public function rules(Request $request)
     {
+        $street_number = $request->street_number;
+        $postcode = $request->postcode;
+        $city = $request->city;
+
         return [
             'first_name' => 'required',
             'last_name' => 'required',
@@ -20,7 +26,16 @@ class PersonUpdateRequest extends FormRequest
             'title_suffix' => 'nullable',
             'gender' => 'required|in:male,female,neutral',
             'address_id' => 'exists:addresses,id|nullable',
-            'street_number' => 'required_with:postcode,city|nullable',
+            'street_number' => [
+                'required_with:postcode,city',
+                'nullable',
+                Rule::unique('addresses')->where(function ($query) use ($street_number, $postcode, $city) {
+                    return $query
+                        ->where('street_number', $street_number)
+                        ->where('postcode', $postcode)
+                        ->where('city', $city);
+                }),
+            ],
             'postcode' => 'required_with:street_number,city|digits_between:4,5|nullable',
             'city' => 'required_with:street_number,postcode|nullable',
             'company_id' => 'exists:companies,id|nullable',

--- a/resources/lang/de/validation.php
+++ b/resources/lang/de/validation.php
@@ -128,8 +128,8 @@ return [
     */
 
     'custom' => [
-        'attribute-name' => [
-            'rule-name' => 'custom-message',
+        'street_number' => [
+            'unique' => 'Eine Addresse mit den angegebenen Daten existiert bereits.',
         ],
     ],
 

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -129,8 +129,8 @@ return [
     */
 
     'custom' => [
-        'attribute-name' => [
-            'rule-name' => 'custom-message',
+        'street_number' => [
+            'unique' => 'An address with the provided data exists already.',
         ],
     ],
 


### PR DESCRIPTION
This extends the unique address validation to company and person forms. It also moves the validation message into the respective language resource files.